### PR TITLE
feat: Add GitHub Action History-hub

### DIFF
--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -1,7 +1,8 @@
 name: History Hub
 on:
+  # web hook event that is corresponding to actions in every spoke repo
   repository_dispatch:
-    types: [readme_updated] # web hook event that is corresponding to actions in every spoke repo
+    types: [readme_updated]
 
 jobs:
   update-readme:

--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -1,0 +1,38 @@
+name: History Hub
+on:
+  repository_dispatch:
+    types: [readme_updated]
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v3
+
+    # each repo
+    - name: Check out infra-repo
+      uses: actions/checkout@v3
+      with:
+        repository: Smile2Buy/s2b-infra
+        path: infra
+        token: ${{ secrets.PAT }}
+
+    - name: Generate merged README.md
+      run: |
+        cp -f skeleton/README.md profile/README.md # Using -f option to overwrite existing out-dated history
+
+        # each repo
+        echo "## Infra implementation history" > profile/README.md
+        grep '\- \[x\]' infra/README.md \
+          | sed 's/- \[x\]/- ![Infra badge](https://img.shields.io/badge/infra-7B42BC)/' \
+          >> profile/README.md
+
+    - name: Commit and push if it changed
+      run: |
+        git diff
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
+        git commit -am "Merge history spokes into hub" || exit 0
+        git push
+

--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v3
 
-    # each repo
+    # Occupied, should create whenever added new spoke
     - name: Check out infra-repo
       uses: actions/checkout@v3
       with:
@@ -19,10 +19,10 @@ jobs:
         token: ${{ secrets.PAT }}
 
     - name: Generate merged README.md
+      # line: cp and echo -> Common, using -f option to overwrite existing out-dated README.md
+      # line: grep -> Occupied, should create whenever adding new spoke
       run: |
-        cp -f skeleton/README.md profile/README.md # Using -f option to overwrite existing out-dated history
-
-        # each repo
+        cp -f skeleton/README.md profile/README.md
         echo "## Infra implementation history" > profile/README.md
         grep '\- \[x\]' infra/README.md \
           | sed 's/- \[x\]/- ![Infra badge](https://img.shields.io/badge/infra-7B42BC)/' \
@@ -33,6 +33,6 @@ jobs:
         git diff
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
-        git commit -am "Merge history spokes into hub" || exit 0
+        git commit -am "Build history-hub by merging history-spokes" || exit 0
         git push
 

--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -1,7 +1,7 @@
 name: History Hub
 on:
   repository_dispatch:
-    types: [readme_updated]
+    types: [readme_updated] # web hook event that is corresponding to actions in every spoke repo
 
 jobs:
   update-readme:

--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -19,7 +19,7 @@ jobs:
         token: ${{ secrets.PAT }}
 
     - name: Generate merged README.md
-      # line: cp and echo -> Common, using -f option to overwrite existing out-dated README.md
+      # line: cp and echo -> Shared, using -f option to overwrite existing out-dated README.md
       # line: grep -> Occupied, should create whenever adding new spoke
       run: |
         cp -f skeleton/README.md profile/README.md

--- a/skeleton/README.md
+++ b/skeleton/README.md
@@ -1,0 +1,3 @@
+# Development log
+> [Check here for details!](https://github.com/orgs/Smile2Buy/projects/1)
+


### PR DESCRIPTION
Resolves #4 

## done
- workflow 추가
- skeleton 추가

## todo
- spoke-branch와 약속된 `readme_updated` 이벤트는 [main] 브랜치에 code-push 시점에 트리거된다.
- 그런데 배포는 tag를 기준으로 이루어지므로 organization home에서 보여주는 history는 배포를 기준으로 하지 않게 된다.
- 작업내역의 의미에는 현행이 더 옳다고 생각하지만 추후 수정이 필요한 경우 바꾸기