### PR TITLE
fix: change delimiter from / to #

### DIFF
--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -26,7 +26,9 @@ jobs:
       run: |
         cp -f skeleton/README.md profile/README.md
         echo "$INFRA_TITLE" > profile/README.md
-        cat infra/README.md | perl -lne 'print if /^(\s*- \[[x]\]|#{3,})/' | sed "s/- \[x\]/- $INFRA_MARKER/" >> profile/README.md
+        cat infra/README.md \
+          | perl -lne 'print if /^(\s*- \[[x]\]|#{3,})/' \
+          | sed "s#- \[x\]#- $INFRA_MARKER#" >> profile/README.md
 
     - name: Commit and push if it changed
       run: |


### PR DESCRIPTION
## done
- seq 문이 delimiter로 '/'를 사용하고 있다.
- 그런데 seq문 안에는 '/'가 포함된 INFRA_MARKER가 참조되고 있다.
- 이에 delimiter를 / 에서 #로 변경함.