### PR TITLE
fix: action-bot to use a personal access token (PAT)

### DIFF
--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -34,5 +34,7 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
         git commit -am "Build history-hub by merging history-spokes" || exit 0
-        git push
+        git push origin HEAD:main --force
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT }}
 


### PR DESCRIPTION
## done
- to use GitHub action-bot to use a personal access token (PAT) instead of the default GITHUB_TOKEN when pushing commits