### PR TITLE
fix: change action to create pr instead of pushing

### DIFF
--- a/.github/workflows/history-hub.yml
+++ b/.github/workflows/history-hub.yml
@@ -30,13 +30,18 @@ jobs:
           | perl -lne 'print if /^(\s*- \[[x]\]|#{3,})/' \
           | sed "s#- \[x\]#- $INFRA_MARKER#" >> profile/README.md
 
-    - name: Commit and push if it changed
+    - name: Create Pull Request
       run: |
-        git diff
-        git config --global user.email "action@github.com"
-        git config --global user.name "GitHub Action"
-        git commit -am "Build history-hub by merging history-spokes" || exit 0
-        git push origin HEAD:main --force
+        git checkout -b changes-branch
+        git add .
+        git commit -m "docs: history across org has been merged"
+        gh pr create \
+          --title "docs: History-hub updated by ${GITHUB_RUN_NUMBER" \
+          --body "" \
+          --base main \
+          --head changes-branch \
+          --repo ${{ github.repository }}
       env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 


### PR DESCRIPTION
Resolves #16 

## done
- 직접 merge하는 것이 아니라 PR을 생성할 때 생길 수 있는 문제를 고려했다.
  - 복수의 repo에서 README.md가 변경되면 반영되지 않은 PR 위로 새로운 PR이 생길 수 있다.
  - 하지만 REAME.md를 merge 하는 로직은 독립적이다.
  - 따라서 이전의 PR이 merge 되었는가와 관계 없이 더 늦게 발생한 event에 의해 생성된 PR은 앞선 시점의 변경사항이 이미 반영되어 있으므로 문제가 되지 않는다.
- 다만, merge 할 때에는 앞선 PR부터 해주는 것이 자연스러우므로 title을 auto increment할 수 있도록 처리했다.